### PR TITLE
Printlogger cleanup

### DIFF
--- a/console/msync.cpp
+++ b/console/msync.cpp
@@ -14,20 +14,18 @@
 #include "optionparsing/parseoptions.hpp"
 
 std::pair<const std::string, user_options>& assume_account(std::pair<const std::string, user_options>* user);
-void print_stringptr(const std::string* toprint, print_logger<>& pl);
+void print_stringptr(const std::string* toprint);
 
 template <typename T>
 void uniqueify(T& toprint);
 
 template <typename T>
-void print_iterable(const T& vec, print_logger<>& pl);
+void print_iterable(const T& vec);
 
 int main(int argc, const char* argv[])
 {
-    print_logger<logtype::fileonly> pl;
-    print_logger<logtype::normal> plerr;
-    pl << "--- msync started ---\n";
-    pl.flush();
+    plfile() << "--- msync started ---\n";
+    plfile().flush();
 
     auto parsed = parse(argc, argv, false);
 
@@ -40,24 +38,24 @@ int main(int argc, const char* argv[])
             make_new_account(parsed.account);
             break;
         case mode::showopt:
-            print_stringptr(assume_account(user).second.get_option(parsed.toset), plerr);
+            print_stringptr(assume_account(user).second.get_option(parsed.toset));
             break;
         case mode::showallopt:
             for (user_option opt = user_option(0); opt <= user_option::pull_notifications; opt = user_option(static_cast<int>(opt) + 1))
             {
-                plerr << USER_OPTION_NAMES[static_cast<int>(opt)] << ": ";
+                pl() << USER_OPTION_NAMES[static_cast<int>(opt)] << ": ";
                 if (opt < user_option::pull_home)
-                    print_stringptr(assume_account(user).second.get_option(opt), plerr);
+                    print_stringptr(assume_account(user).second.get_option(opt));
                 else
-                    plerr << SYNC_SETTING_NAMES[static_cast<int>(assume_account(user).second.get_sync_option(opt))];
-                plerr << '\n';
+                    pl() << SYNC_SETTING_NAMES[static_cast<int>(assume_account(user).second.get_sync_option(opt))];
+                pl() << '\n';
             }
-            plerr << "Accounts registered: ";
+            pl() << "Accounts registered: ";
             for (auto it = options.accounts.begin(); it != options.accounts.end();)
             {
-                plerr << it->first;
+                pl() << it->first;
                 if (++it != options.accounts.end())
-                    plerr << ", ";
+                    pl() << ", ";
             }
             break;
         case mode::config:
@@ -77,24 +75,24 @@ int main(int argc, const char* argv[])
 				clear(parsed.queue_opt.selected, assume_account(user).first);
 				break;
 			case queue_action::print:
-				print_iterable(print(parsed.queue_opt.selected, assume_account(user).first), plerr);
+				print_iterable(print(parsed.queue_opt.selected, assume_account(user).first));
 				break;
 			}
         case mode::help:
             break;
         default:
-            plerr << "[option not implemented]";
+            pl() << "[option not implemented]";
         }
     }
     catch (const std::exception& e)
     {
-        plerr << "An error occurred: " << e.what();
-        plerr << "\nFor account: " << parsed.account;
+        pl() << "An error occurred: " << e.what();
+        pl() << "\nFor account: " << parsed.account;
     }
 
-    plerr << '\n';
+    pl() << '\n';
 
-    pl << "--- msync finished normally ---\n";
+    pl() << "--- msync finished normally ---\n";
 }
 
 template <typename T>
@@ -111,19 +109,19 @@ std::pair<const std::string, user_options>& assume_account(std::pair<const std::
     return *user;
 }
 
-void print_stringptr(const std::string* toprint, print_logger<>& pl)
+void print_stringptr(const std::string* toprint)
 {
     if (toprint == nullptr)
-        pl << "[not set]";
+        pl() << "[not set]";
     else
-        pl << *toprint;
+        pl() << *toprint;
 }
 
 template <typename T>
-void print_iterable(const T& vec, print_logger<>& pl)
+void print_iterable(const T& vec)
 {
 	for (auto& item : vec)
 	{
-		pl << item << '\n';
+		pl() << item << '\n';
 	}
 }

--- a/console/newaccount.cpp
+++ b/console/newaccount.cpp
@@ -14,7 +14,6 @@ const auto redirect_uri = "urn:ietf:wg:oauth:2.0:oob";
 
 void make_new_account(const std::string& accountname)
 {
-    print_logger<logtype::normal> pl;
     auto useraccountpair = options.select_account(accountname);
 
     // see: https://docs.joinmastodon.org/api/authentication/
@@ -22,11 +21,11 @@ void make_new_account(const std::string& accountname)
     // if no user was found, make a new one
     if (useraccountpair == nullptr)
     {
-        pl << "Creating new account for " << accountname << "\n";
+        pl() << "Creating new account for " << accountname << "\n";
         auto parsed = parse_account_name(accountname);
         if (!parsed.has_value())
         {
-            pl << "Could not parse a username and instance name from: " << accountname << ". It should look like: username@instance.url\n";
+            pl() << "Could not parse a username and instance name from: " << accountname << ". It should look like: username@instance.url\n";
             return;
         }
         // make a new account
@@ -36,7 +35,7 @@ void make_new_account(const std::string& accountname)
     }
     else
     {
-        pl << "Existing user found.\n";
+        pl() << "Existing user found.\n";
     }
     
 	auto& useraccount = useraccountpair->second;
@@ -48,25 +47,25 @@ void make_new_account(const std::string& accountname)
     auto instanceurl = *useraccount.get_option(user_option::instance_url);
     if (client_id == nullptr || client_secret == nullptr)
     {
-        pl << "Registering app with " << instanceurl << '\n';
+        pl() << "Registering app with " << instanceurl << '\n';
         auto r = cpr::Post(cpr::Url{make_api_url(instanceurl, "/api/v1/apps")},
                            cpr::Parameters{{"client_name", "msync"}, {"redirect_uris", redirect_uri}, {"scopes", scopes}, {"website", "https://github.com/kansattica/msync"}});
 
         if (r.error)
         {
-            pl << "Could not register app with server. Responded with error code " << r.status_code << ": " << r.error.message << '\n';
-            pl << "Please try again.\n";
+            pl() << "Could not register app with server. Responded with error code " << r.status_code << ": " << r.error.message << '\n';
+            pl() << "Please try again.\n";
             return;
         }
 
         json parsed = json::parse(r.text);
         useraccount.set_option(user_option::client_id, parsed["client_id"].get<std::string>());
         useraccount.set_option(user_option::client_secret, parsed["client_secret"].get<std::string>());
-        pl << "Registered!\n";
+        pl() << "Registered!\n";
     }
     else
     {
-        pl << "App already registered.\n";
+        pl() << "App already registered.\n";
     }
 
     if (client_id == nullptr)
@@ -76,7 +75,7 @@ void make_new_account(const std::string& accountname)
     if (authcode == nullptr)
     {
         auto foundaccountname = *useraccount.get_option(user_option::account_name);
-        pl << "Please open this URL in your browser:\n"
+        pl() << "Please open this URL in your browser:\n"
            << "https://" << instanceurl << "/oauth/authorize?response_type=code&client_id=" << *client_id
            << "&redirect_uri=" << redirect_uri << "&scope=" << urlscopes << '\n'
            << "Enter your authorization code like so:\n"
@@ -91,11 +90,11 @@ void make_new_account(const std::string& accountname)
     auto access_token = useraccount.get_option(user_option::access_token);
     if (access_token != nullptr)
     {
-        pl << "Your account is already registered! You're done!\n";
+        pl() << "Your account is already registered! You're done!\n";
         return;
     }
 
-    pl << "Getting access token from server with authorization code.\n";
+    pl() << "Getting access token from server with authorization code.\n";
     auto response = cpr::Post(cpr::Url{make_api_url(instanceurl, "/oauth/token")}, 
         cpr::Parameters{{"client_id", *client_id}, {"client_secret", *client_secret}, {"grant_type", "authorization_code"}, 
         {"code", *authcode}, {"redirect_uri", redirect_uri}});
@@ -104,7 +103,7 @@ void make_new_account(const std::string& accountname)
     if (response.error)
     {
         auto foundaccountname = *useraccount.get_option(user_option::account_name);
-        pl << "Could not get access token from server. Authorization codes can only be used once, so it's been deleted and you should get another one.\n"
+        pl() << "Could not get access token from server. Authorization codes can only be used once, so it's been deleted and you should get another one.\n"
            << "Please open this URL in your browser:\n"
            << "https://" << instanceurl << "/oauth/authorize?response_type=code&client_id=" << *client_id
            << "&redirect_uri=" << redirect_uri << "&scope=" << urlscopes << '\n'
@@ -117,7 +116,7 @@ void make_new_account(const std::string& accountname)
 
     json parsed = json::parse(response.text);
     useraccount.set_option(user_option::access_token, parsed["access_token"].get<std::string>());
-    pl << "Done! You're ready to start using this account.\n";
+    pl() << "Done! You're ready to start using this account.\n";
 
     //don't need these any more once we're good
     useraccount.set_option(user_option::client_id, "");

--- a/lib/filebacked/file_backed.hpp
+++ b/lib/filebacked/file_backed.hpp
@@ -13,11 +13,10 @@ public:
     Container parsed;
 	file_backed(fs::path filename) : backing(filename)
 	{
-		print_logger<logtype::verbose> logger;
 		std::ifstream backingfile(backing);
 		for (std::string line; getline(backingfile, line);)
 		{
-			logger << "Parsing line: " << line << '\n';
+			plverb() << "Parsing line: " << line << '\n';
 
 			const auto first_non_whitespace = line.find_first_not_of(" \t\r\n");
 
@@ -36,15 +35,13 @@ public:
 		if (backing == "")
 			return; // we got moved from, so the new version will save it
 
-		print_logger<logtype::verbose> logger;
-
 		fs::path backup(backing);
 		backup += ".bak";
 
 		if (fs::exists(backing))
 		{
 			fs::rename(backing, backup);
-			logger << "Saved backup to " << backup << '\n';
+			plverb() << "Saved backup to " << backup << '\n';
 		}
 
 		ofstream of(backing);
@@ -53,7 +50,7 @@ public:
 			Write(elem, of);
 		}
 
-		logger << "Saved " << backing << '\n';
+		plverb() << "Saved " << backing << '\n';
 	}
 
 	// can be moved

--- a/lib/options/global_options.cpp
+++ b/lib/options/global_options.cpp
@@ -14,7 +14,6 @@ using namespace std::string_literals;
 
 std::pair<const std::string, user_options>& global_options::add_new_account(std::string name)
 {
-    print_logger<logtype::verbose> pl;
     fs::path user_path = executable_location;
     user_path /= Account_Directory;
     user_path /= name;
@@ -26,7 +25,7 @@ std::pair<const std::string, user_options>& global_options::add_new_account(std:
     const auto [it, inserted] = accounts.emplace(name, user_options{user_path});
 
     if (!inserted)
-        pl << "Account already exists. Nothing changed.\n";
+        plverb() << "Account already exists. Nothing changed.\n";
 
     return *it;
 }
@@ -45,11 +44,9 @@ fs::path global_options::get_exe_location()
 
 std::unordered_map<std::string, user_options> global_options::read_accounts()
 {
-    print_logger<logtype::verbose> pl;
-
     fs::path account_location = executable_location / Account_Directory;
 
-    pl << "Reading accounts from " << account_location << "\n";
+    plverb() << "Reading accounts from " << account_location << "\n";
 
     std::unordered_map<std::string, user_options> toreturn;
 
@@ -60,7 +57,7 @@ std::unordered_map<std::string, user_options> global_options::read_accounts()
     {
         if (!fs::is_directory(userfolder))
         {
-            pl << userfolder << " is not a directory. Skipping.\n";
+            plverb() << userfolder << " is not a directory. Skipping.\n";
             continue;
         }
 
@@ -82,8 +79,6 @@ std::unordered_map<std::string, user_options> global_options::read_accounts()
 
 std::pair<const std::string, user_options>* global_options::select_account(const std::string_view name)
 {
-    print_logger<logtype::verbose> pl;
-
     int matched = 0;
 	std::pair<const std::string, user_options>* candidate = nullptr;
 
@@ -101,7 +96,7 @@ std::pair<const std::string, user_options>* global_options::select_account(const
                 return std::tolower(a) == std::tolower(b); //case insensitive
             }))
         {
-            pl << "Matched account" << entry.first << "\n";
+            plverb() << "Matched account" << entry.first << "\n";
             matched++;
             candidate = &entry;
         }

--- a/lib/printlog/print_logger.cpp
+++ b/lib/printlog/print_logger.cpp
@@ -2,3 +2,21 @@
 
 bool verbose_logs;
 bool logs_off = false;
+
+print_logger<logtype::normal>& pl()
+{
+	static print_logger<logtype::normal> pl;
+	return pl;
+}
+
+print_logger<logtype::verbose>& plverb()
+{
+	static print_logger<logtype::verbose> pl;
+	return pl;
+}
+
+print_logger<logtype::fileonly>& plfile()
+{
+	static print_logger<logtype::fileonly> pl;
+	return pl;
+}

--- a/lib/printlog/print_logger.hpp
+++ b/lib/printlog/print_logger.hpp
@@ -51,4 +51,8 @@ struct print_logger
 private:
     ofstream logfile;
 };
+
+print_logger<logtype::normal>& pl();
+print_logger<logtype::verbose>& plverb();
+print_logger<logtype::fileonly>& plfile();
 #endif

--- a/lib/queue/queues.cpp
+++ b/lib/queue/queues.cpp
@@ -28,18 +28,17 @@ void unique_file_name(fs::path& path)
 
 std::string queue_post(const fs::path& queuedir, const fs::path& postfile)
 {
-	print_logger pl;
 	fs::create_directories(queuedir);
 
 	if (!fs::exists(postfile))
 	{
-		pl << "Could not find " << postfile << ". Skipping.\n";
+		pl() << "Could not find " << postfile << ". Skipping.\n";
 		return "";
 	}
 
 	if (!fs::is_regular_file(postfile))
 	{
-		pl << postfile << " is not a file. Skipping.\n";
+		pl() << postfile << " is not a file. Skipping.\n";
 		return "";
 	}
 
@@ -47,9 +46,9 @@ std::string queue_post(const fs::path& queuedir, const fs::path& postfile)
 
 	if (fs::exists(copyto))
 	{
-		pl << copyto << " already exists. " << postfile << " will be saved as ";
+		pl() << copyto << " already exists. " << postfile << " will be saved as ";
 		unique_file_name(copyto);
-		pl << copyto << '\n';
+		pl() << copyto << '\n';
 	}
 
 	fs::copy(postfile, copyto);
@@ -100,10 +99,9 @@ void enqueue(const queues toenqueue, const std::string& account, const std::vect
 
 void dequeue_post(const fs::path &queuedir, const fs::path& filename)
 {
-	print_logger pl;
 	if (!fs::remove(queuedir / filename))
 	{
-		pl << "Could not delete " << filename << ", could not find it in " << queuedir << '\n';
+		pl() << "Could not delete " << filename << ", could not find it in " << queuedir << '\n';
 	}
 }
 


### PR DESCRIPTION
- use magic statics to ensure correct, thread-safe initialization
- stop passing printloggers around and cluttering function signatures.