### PR TITLE
Add xdg directory spec option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project (msync VERSION 0.9.5
 	LANGUAGES CXX C)
 
 option(MSYNC_BUILD_TESTS "Download catch2 and build tests with it." ON)
-
+option(MSYNC_USE_XDG_DIRECTORIES "Use xdg standard directory layout for files used." OFF)
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) #enable interprocedural optimization for all projects
 
 include(cmake/linktimeoptimization.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project (msync VERSION 0.9.5
 
 option(MSYNC_BUILD_TESTS "Download catch2 and build tests with it." ON)
 option(MSYNC_USE_XDG_DIRECTORIES "Use xdg standard directory layout for files used." OFF)
+set(MSYNC_BASE_DIRECTORY "" CACHE PATH "What directory to use as base.")
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) #enable interprocedural optimization for all projects
 
 include(cmake/linktimeoptimization.cmake)

--- a/lib/accountdirectory/CMakeLists.txt
+++ b/lib/accountdirectory/CMakeLists.txt
@@ -3,7 +3,7 @@ target_sources_local(accountdirectory
 	account_directory.cpp
 	account_directory.hpp
 	)
-if(MSYNC_USE_XDG_DIRECTORIES OR MSYNC_BASE_DIRECTORY EQUAL "")
+if(MSYNC_USE_XDG_DIRECTORIES OR MSYNC_BASE_DIRECTORY STREQUAL "")
   target_compile_definitions(accountdirectory
     PRIVATE USE_XDG_DIRECTORY_SPEC=1)
 else()

--- a/lib/accountdirectory/CMakeLists.txt
+++ b/lib/accountdirectory/CMakeLists.txt
@@ -3,3 +3,7 @@ target_sources_local(accountdirectory
 	account_directory.cpp
 	account_directory.hpp
 	)
+if(MSYNC_USE_XDG_DIRECTORIES)
+  target_compile_definitions(accountdirectory
+    PRIVATE USE_XDG_DIRECTORY_SPEC=1)
+endif()

--- a/lib/accountdirectory/CMakeLists.txt
+++ b/lib/accountdirectory/CMakeLists.txt
@@ -3,7 +3,7 @@ target_sources_local(accountdirectory
 	account_directory.cpp
 	account_directory.hpp
 	)
-if(MSYNC_USE_XDG_DIRECTORIES)
+if(MSYNC_USE_XDG_DIRECTORIES OR MSYNC_BASE_DIRECTORY EQUAL "")
   target_compile_definitions(accountdirectory
     PRIVATE USE_XDG_DIRECTORY_SPEC=1)
 else()

--- a/lib/accountdirectory/CMakeLists.txt
+++ b/lib/accountdirectory/CMakeLists.txt
@@ -6,4 +6,8 @@ target_sources_local(accountdirectory
 if(MSYNC_USE_XDG_DIRECTORIES)
   target_compile_definitions(accountdirectory
     PRIVATE USE_XDG_DIRECTORY_SPEC=1)
+else()
+  target_compile_definitions(accountdirectory
+    PRIVATE MSYNC_BASE_DIRECTORY=\"${MSYNC_BASE_DIRECTORY}\"
+    USING_MSYNC_BASE_DIRECTORY=1)
 endif()

--- a/lib/accountdirectory/account_directory.cpp
+++ b/lib/accountdirectory/account_directory.cpp
@@ -15,7 +15,9 @@
 #endif
 fs::path get_executable_folder()
 {
-#ifdef USE_XDG_DIRECTORY_SPEC
+#if USING_MSYNC_BASE_DIRECTORY==1
+	return fs::path{MSYNC_BASE_DIRECTORY};
+#elif defined(USE_XDG_DIRECTORY_SPEC)
 	fs::path to_return;
 	char *env_value=nullptr;
 	// If this environmental variable is set it overrides the usual ~/.config/<stuff> paths
@@ -33,7 +35,7 @@ fs::path get_executable_folder()
 	// whereami doesn't work on arm processors for some reason, and also whereami uses PATH_MAX on Linux which you shouldn't do
 	// (see https://linux.die.net/man/3/realpath, stackoverflow answers, and blogs that say you shouldn't use PATH_MAX)
 	// so use the correct form of realpath on linux and whereami everywhere else
-#elif defined(__linux__)
+#elif defined(__linux__) 
 	// this version of realpath malloc()s a buffer and returns it, so we use unique_ptr to free it automatically.
 	std::unique_ptr<char[], decltype(std::free)*> full_executable_path { realpath("/proc/self/exe", NULL), std::free };
 	fs::path to_return { full_executable_path.get() };

--- a/lib/accountdirectory/account_directory.cpp
+++ b/lib/accountdirectory/account_directory.cpp
@@ -10,13 +10,30 @@
 #include <string>
 #include <whereami.h>
 #endif
-
+#ifdef USE_XDG_DIRECTORY_SPEC
+#include <cstdlib>
+#endif
 fs::path get_executable_folder()
 {
+#ifdef USE_XDG_DIRECTORY_SPEC
+	fs::path to_return;
+	char *env_value=nullptr;
+	// If this environmental variable is set it overrides the usual ~/.config/<stuff> paths
+	if((env_value = getenv("XDG_CONFIG_HOME")) != nullptr)
+	{
+		to_return = env_value;
+	}
+	else
+	{
+		to_return = getenv("HOME");
+		to_return/=".config";
+	}
+	to_return/="msync";
+	return to_return;
 	// whereami doesn't work on arm processors for some reason, and also whereami uses PATH_MAX on Linux which you shouldn't do
 	// (see https://linux.die.net/man/3/realpath, stackoverflow answers, and blogs that say you shouldn't use PATH_MAX)
 	// so use the correct form of realpath on linux and whereami everywhere else
-#ifdef __linux__
+#elif defined(__linux__)
 	// this version of realpath malloc()s a buffer and returns it, so we use unique_ptr to free it automatically.
 	std::unique_ptr<char[], decltype(std::free)*> full_executable_path { realpath("/proc/self/exe", NULL), std::free };
 	fs::path to_return { full_executable_path.get() };


### PR DESCRIPTION
It's nice to have config stuff placed in `~/.config/msync`, if for no other reason that it tends to jive better with the typical behavior of linux/unix/mac software.