### PR TITLE
Fix up compiler flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,11 @@ include(cmake/linktimeoptimization.cmake)
 
 include(cmake/packages.cmake)
 
-
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
+
+include(cmake/compilerflags.cmake)
 
 add_library(queue STATIC "")
 add_library(sync STATIC "")
@@ -38,7 +39,6 @@ add_library(constants INTERFACE)
 add_library(exception INTERFACE)
 add_executable(msync "")
 
-include(cmake/compilerflags.cmake)
 
 # see https://crascit.com/2016/01/31/enhanced-source-file-handling-with-target_sources/
 include(cmake/compatibility.cmake)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cmake --build . --parallel
 
 The last two steps will take a while, but when you're done, you should see a `msync` executable in your folder, and that's all you need! 
 
-Older Ubuntu releases might require you to `apt install g++-8 libstdc++-8-dev` and run `CC=gcc-8 CXX=g++-8 cmake .. -DCMAKE_BUILD_TYPE=Release -DMSYNC_BUILD_TESTS=OFF` instead, in order to get and use a version of the standard library that supports std::filesystem.
+Older Linux releases might require you to `apt install g++-8 libstdc++-8-dev` and run `CC=gcc-8 CXX=g++-8 cmake .. -DCMAKE_BUILD_TYPE=Release -DMSYNC_BUILD_TESTS=OFF` instead, in order to get and use a version of the standard library that supports std::filesystem.
 
 #### Building on macOS
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cmake --build . --parallel
 
 The last two steps will take a while, but when you're done, you should see a `msync` executable in your folder, and that's all you need! 
 
-Older Linux releases might require you to `apt install g++-8 libstdc++-8-dev` and run `CC=gcc-8 CXX=g++-8 cmake .. -DCMAKE_BUILD_TYPE=Release -DMSYNC_BUILD_TESTS=OFF` instead, in order to get and use a version of the standard library that supports std::filesystem.
+Older Linux releases might require you to `apt install libstdc++-8-dev` or their equivalent to get the standard library features `msync` requires, such as std::filesystem. If that doesn't work, you may also need `g++-8` and to run `CC=gcc-8 CXX=g++-8 cmake .. -DCMAKE_BUILD_TYPE=Release -DMSYNC_BUILD_TESTS=OFF` instead.
 
 #### Building on macOS
 

--- a/cmake/compilerflags.cmake
+++ b/cmake/compilerflags.cmake
@@ -3,9 +3,3 @@ if (MSVC)
 else()
 	add_compile_options(-Wall -Wextra -pedantic)
 endif()
-
-# basically, if you compile CPR with LTO enabled, the gnu compiler emits a bunch of spurious ODR warnings for every library that includes CPR.
-# this quiets that down.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	add_link_options("-Wno-odr")
-endif()

--- a/cmake/compilerflags.cmake
+++ b/cmake/compilerflags.cmake
@@ -7,5 +7,5 @@ endif()
 # basically, if you compile CPR with LTO enabled, the gnu compiler emits a bunch of spurious ODR warnings for every library that includes CPR.
 # this quiets that down.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	set_target_properties(msync PROPERTIES LINK_FLAGS "-Wno-odr")
+	add_link_options("-Wno-odr")
 endif()

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -7,3 +7,9 @@ target_sources_local(msync
 )
 
 configure_file(version.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/version.hpp)
+
+# basically, if you compile CPR with LTO enabled, the gnu compiler emits a bunch of spurious ODR warnings for every library that includes CPR.
+# this quiets that down.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	set_target_properties(msync PROPERTIES LINK_FLAGS "-Wno-odr")
+endif()

--- a/console/msync.cpp
+++ b/console/msync.cpp
@@ -24,7 +24,7 @@ std::pair<const std::string, user_options>& assume_account(select_account_result
 
 void do_sync(const parse_result& parsed);
 
-void show_all_options(select_account_result user_result, const parse_result& parsed);
+void show_all_options(select_account_result user_result);
 
 void print_stringptr(const std::string* toprint);
 void print_sensitive(std::string_view name, const std::string* value);
@@ -53,7 +53,7 @@ int main(int argc, const char* argv[])
 			break;
 		case mode::showallopt:
 			should_print_newline = false;
-			show_all_options(options().select_account(parsed.account), parsed);
+			show_all_options(options().select_account(parsed.account));
 			break;
 		case mode::config:
 			should_print_newline = false;
@@ -209,7 +209,7 @@ bool is_sensitive(user_option opt)
 	return false;
 }
 
-void show_all_options(select_account_result user_result, const parse_result& parsed)
+void show_all_options(select_account_result user_result)
 {
 	pl() << "Accounts registered:\n";
 	{

--- a/lib/postfile/outgoing_post.cpp
+++ b/lib/postfile/outgoing_post.cpp
@@ -25,8 +25,6 @@ std::string post_content::visibility_string() const
 	return std::string{ VISIBILITIES[static_cast<int>(vis)][0] };
 }
 
-const char vector_delimiter = '`';
-
 int is_option(std::string_view line, size_t equals_sign);
 bool is_snip(std::string_view line);
 void parse_option(post_content& post, size_t option_index, std::string_view value);

--- a/lib/sync/read_response.cpp
+++ b/lib/sync/read_response.cpp
@@ -151,7 +151,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(notif_type, {
 		{ notif_type::boost, "reblog" },
 		{ notif_type::poll, "poll" },
 		{ notif_type::favorite, "favourite" },
-	});
+	})
 
 void from_json(const json& j, mastodon_notification& notif)
 {


### PR DESCRIPTION
- Fix the warnings created when I accidentally messed up adding the warning flags
- Windows now prints a proper UTF-8 yeehaw again