### PR TITLE
OSX install build and better account_directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
   - os: osx
     osx_image: xcode11
     compiler: clang
+  - os: osx
+    osx_image: xcode11
+    compiler: clang
+    env: CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
   - os: linux
     dist: bionic
     compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ matrix:
     env: BUILD_ARCH=x64 CC="/usr/bin/clang-7" CXX="/usr/bin/clang++-7"
     addons:
       apt: clang-7 llvm-7-dev libstdc++-8-dev
-  - os: osx
-    osx_image: xcode11
-    compiler: clang
-  - os: osx
-    osx_image: xcode11
-    compiler: clang
-    env: CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
   - os: linux
     dist: bionic
     compiler: gcc
@@ -41,6 +34,19 @@ matrix:
         - libcurl4-openssl-dev:i386
         - linux-libc-dev:i386
         - libstdc++-8-dev
+  - os: linux
+    dist: bionic
+    compiler: gcc
+    env: BUILD_ARCH=x64 CC=gcc-8 CXX=g++-8 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF" MAKE_DEB=TRUE
+    addons:
+      apt: g++-8 libstdc++-8-dev
+  - os: osx
+    osx_image: xcode11
+    compiler: clang
+  - os: osx
+    osx_image: xcode11
+    compiler: clang
+    env: CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
   - os: windows
     compiler: cl64.exe
     env: CMAKE_GENERATOR="Visual Studio 15 2017" CMAKE_GENERATOR_PLATFORM=x64
@@ -53,12 +59,6 @@ matrix:
   - os: windows
     compiler: cl32.exe
     env: CMAKE_GENERATOR="Visual Studio 15 2017" CMAKE_GENERATOR_PLATFORM=win32 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
-  - os: linux
-    dist: bionic
-    compiler: gcc
-    env: BUILD_ARCH=x64 CC=gcc-8 CXX=g++-8 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF" MAKE_DEB=TRUE
-    addons:
-      apt: g++-8 libstdc++-8-dev
 
 script:
   - export BUILDTYPE=Release 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,31 +34,31 @@ matrix:
         - libcurl4-openssl-dev:i386
         - linux-libc-dev:i386
         - libstdc++-8-dev
-  - os: linux
-    dist: bionic
-    compiler: gcc
-    env: BUILD_ARCH=x64 CC=gcc-8 CXX=g++-8 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF" MAKE_DEB=TRUE
-    addons:
-      apt: g++-8 libstdc++-8-dev
   - os: osx
     osx_image: xcode11
     compiler: clang
-  - os: osx
-    osx_image: xcode11
-    compiler: clang
-    env: CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
   - os: windows
     compiler: cl64.exe
     env: CMAKE_GENERATOR="Visual Studio 15 2017" CMAKE_GENERATOR_PLATFORM=x64
   - os: windows
     compiler: cl32.exe
     env: CMAKE_GENERATOR="Visual Studio 15 2017" CMAKE_GENERATOR_PLATFORM=win32
+  - os: osx
+    osx_image: xcode11
+    compiler: clang
+    env: CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
   - os: windows
     compiler: cl64.exe
     env: CMAKE_GENERATOR="Visual Studio 15 2017" CMAKE_GENERATOR_PLATFORM=x64 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
   - os: windows
     compiler: cl32.exe
     env: CMAKE_GENERATOR="Visual Studio 15 2017" CMAKE_GENERATOR_PLATFORM=win32 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF"
+  - os: linux
+    dist: bionic
+    compiler: gcc
+    env: BUILD_ARCH=x64 CC=gcc-8 CXX=g++-8 CONFIGURE_ARGUMENTS="-DMSYNC_USER_CONFIG=ON -DMSYNC_FILE_LOG=OFF" MAKE_DEB=TRUE
+    addons:
+      apt: g++-8 libstdc++-8-dev
 
 script:
   - export BUILDTYPE=Release 

--- a/lib/accountdirectory/account_directory.cpp
+++ b/lib/accountdirectory/account_directory.cpp
@@ -76,8 +76,14 @@ fs::path get_executable_folder()
 
 #endif
 
+fs::path account_directory_path_uncached()
+{
+	return get_config_folder().append(Account_Directory);
+}
+
 const fs::path& account_directory_path()
 {
-	const static fs::path folder = get_config_folder().append(Account_Directory);
+	const static fs::path folder = account_directory_path_uncached();
 	return folder;
 }
+

--- a/lib/accountdirectory/account_directory.cpp
+++ b/lib/accountdirectory/account_directory.cpp
@@ -12,7 +12,7 @@
 // - Windows and OSX use whereami
 
 #ifdef MSYNC_USER_CONFIG
-	#ifdef __WIN32
+	#ifdef _WIN32
 		#define WIN32_LEAN_AND_MEAN
 		#include <windows.h>
 		#include <shlobj.h>
@@ -34,7 +34,7 @@
 
 fs::path get_user_config_folder_base()
 {
-#ifdef __WIN32
+#ifdef _WIN32
 	PWSTR appdata_path = nullptr;
 	auto hresult = ::SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_DEFAULT, nullptr, &appdata_path);
 	if (SUCCEEDED(hresult)) {

--- a/lib/accountdirectory/account_directory.hpp
+++ b/lib/accountdirectory/account_directory.hpp
@@ -5,4 +5,9 @@
 
 const fs::path& account_directory_path();
 
+//I hate having this sort of thing that's only for testing, but the static version of account_directory_path is what we want every other time.
+#ifdef MSYNC_TESTING
+fs::path account_directory_path_uncached();
+#endif
+
 #endif

--- a/tests/account_directory.cpp
+++ b/tests/account_directory.cpp
@@ -35,10 +35,11 @@ SCENARIO("account_directory_path returns the same correct path every time.")
 #ifndef MSYNC_USER_CONFIG
 		THEN("The test executable exists in the parent directory.")
 		{
+			constexpr auto filename = 
 #ifdef _WIN32
-			constexpr auto filename = "tests.exe";
+			"tests.exe";
 #else
-			constexpr auto filename = "tests";
+			"tests";
 #endif
 			REQUIRE(fs::exists(account_dir.parent_path() / filename));
 		}
@@ -77,7 +78,7 @@ SCENARIO("The account directory locator respects MSYNC_USER_CONFIG.")
 		constexpr auto xdg_home = "XDG_CONFIG_HOME";
 		// the string that getenv returns changes when you call setenv, so save it off
 		const auto oldhome = getenv(xdg_home);
-		std::string old_home_val = oldhome == nullptr ? "" : oldhome;
+		const std::string old_home_val = oldhome == nullptr ? "" : oldhome;
 
 		WHEN("XDG_CONFIG_HOME is unset.")
 		{
@@ -102,9 +103,11 @@ SCENARIO("The account directory locator respects MSYNC_USER_CONFIG.")
 			}
 		}
 
-		setenv(xdg_home, old_home_val.c_str(), true);
+		if (oldhome == nullptr)
+			unsetenv(xdg_home);
+		else
+			setenv(xdg_home, old_home_val.c_str(), true);
 	}
-
 	#endif
 }
 #endif

--- a/tests/account_directory.cpp
+++ b/tests/account_directory.cpp
@@ -65,7 +65,7 @@ SCENARIO("The account directory locator respects MSYNC_USER_CONFIG.")
 
 		THEN("On Windows, the path ends with AppData/Local/msync/msync_accounts.")
 		{
-			const auto path_iterator = account_dir.end();
+			auto path_iterator = account_dir.end();
 			REQUIRE(*(--path_iterator) == Account_Directory);
 			REQUIRE(*(--path_iterator) == "msync");
 			REQUIRE(*(--path_iterator) == "Local");

--- a/tests/account_directory.cpp
+++ b/tests/account_directory.cpp
@@ -2,7 +2,7 @@
 
 #include <constants.hpp>
 
-#if !defined(__WIN32) && defined(MSYNC_USER_CONFIG)
+#if !defined(_WIN32) && defined(MSYNC_USER_CONFIG)
 	#include <cstdlib>
 	#include "test_helpers.hpp"
 	#include <string>
@@ -57,7 +57,7 @@ SCENARIO("account_directory_path returns the same correct path every time.")
 #ifdef MSYNC_USER_CONFIG
 SCENARIO("The account directory locator respects MSYNC_USER_CONFIG.")
 {
-	#ifdef __WIN32
+	#ifdef _WIN32
 	GIVEN("The account directory path.")
 	{
 		const auto account_dir = account_directory_path();


### PR DESCRIPTION
- Offer an OSX install build
- OSX builds now respect `XDG_CONFIG_HOME` when `MSYNC_USER_CONFIG` is set.
- Make preprocessor define route in account_directory cleaner
- If `MSYNC_USER_CONFIG` is off, use realpath if available to find where the executable is, otherwise use `whereami`.
- Unit test whether account_directory properly respects `MSYNC_USER_CONFIG` , including testing with `XDG_CONFIG_HOME` on platforms that support it.