### PR TITLE
fix registering app with pleroma

### DIFF
--- a/console/new_account.cpp
+++ b/console/new_account.cpp
@@ -71,7 +71,7 @@ void make_new_account(const std::string& accountname, global_options& options)
 	{
 		pl() << "Registering app with " << instanceurl << ".\n";
 		const auto r = cpr::Post(cpr::Url{make_api_url(instanceurl, "/api/v1/apps")},
-						   cpr::Parameters{{"client_name", "msync"}, {"redirect_uris", redirect_uri}, {"scopes", scopes}, {"website", "https://github.com/kansattica/msync"}});
+						   cpr::Payload{{"client_name", "msync"}, {"redirect_uris", redirect_uri}, {"scopes", scopes}, {"website", "https://github.com/kansattica/msync"}});
 
 		if (r.error)
 		{
@@ -117,8 +117,8 @@ void make_new_account(const std::string& accountname, global_options& options)
 	}
 
 	pl() << "Getting access token from server with authorization code.\n";
-	const auto response = cpr::Post(cpr::Url{make_api_url(instanceurl, "/oauth/token")}, 
-		cpr::Parameters{{"client_id", *client_id}, {"client_secret", *client_secret}, {"grant_type", "authorization_code"}, 
+	const auto response = cpr::Post(cpr::Url{make_api_url(instanceurl, "/oauth/token")},
+		cpr::Payload{{"client_id", *client_id}, {"client_secret", *client_secret}, {"grant_type", "authorization_code"},
 		{"code", *authcode}, {"redirect_uri", redirect_uri}});
 
 	useraccount.set_option(user_option::auth_code, "");

--- a/console/new_account.cpp
+++ b/console/new_account.cpp
@@ -73,9 +73,10 @@ void make_new_account(const std::string& accountname, global_options& options)
 		const auto r = cpr::Post(cpr::Url{make_api_url(instanceurl, "/api/v1/apps")},
 						   cpr::Payload{{"client_name", "msync"}, {"redirect_uris", redirect_uri}, {"scopes", scopes}, {"website", "https://github.com/kansattica/msync"}});
 
-		if (r.error)
+		if (r.error || r.status_code != 200)
 		{
 			pl() << "Could not register app with server. Responded with error code " << r.status_code << ": " << r.error.message << ".\n"
+			"Response body: " << r.text << "\n"
 			"Please double check your instance URL, ensure you're connected to the internet, and try again.";
 			return;
 		}


### PR DESCRIPTION
Hello dear Grace.

Yesterday i tried  to register this application with my account on pleroma, but sadly it failed with the following message (not using the real domain name in the message):
```
Creating new account for test@social.example.org.
Registering app with social.example.org.
An error occurred: [json.exception.type_error.302] type must be string, but is null
For account: test@social.example.org
```
It turns out, that pleroma is ignoring the url parameters, most likely, because it is a `POST`  request.
I altered the requests to use a post payload and had success with it. :)

I tested registering with pleroma and mastodon with these changes and it worked for me.
If you have no objections, i would be happy to see these changes merged. :)